### PR TITLE
made FileManager store File and not open it each time

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -87,16 +87,6 @@ pub(crate) enum WriteToFileError {
     #[error("unexpected error")]
     UnexpectedError(std::io::Error),
 }
-pub(crate) fn write_to_file(file_name: &str, text: &str) -> Result<(), WriteToFileError> {
-    let mut file = match std::fs::OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(file_name)
-    {
-        Ok(f) => f,
-        Err(e) => {
-            return Err(WriteToFileError::UnexpectedError(e));
-        }
-    };
+pub(crate) fn write_to_file(file: &mut std::fs::File, text: &str) -> Result<(), WriteToFileError> {
     writeln!(file, "{}", text).map_err(WriteToFileError::UnexpectedError)
 }


### PR DESCRIPTION
## Overview
As mentioned in the #9 the logic of writing to a file has been changed. Before, each time we wrote a log to file, we opened the file, wrote a log, closed the file.

This pull request changes this logic to storing the file in the memory (so it opens once), and closes only on rotation or when the application closes.

## Performance comparison
#### Printing 10000 logs and writing to a file
Before:
```
Time elapsed: 239.863125ms
```

After:
```
Time elapsed: 69.116042ms
```

#### Printing 1 million logs and writing to a file
Before:
```
Time elapsed: 21.669482208s
```

After:
```
Time elapsed: 5.41291075s


